### PR TITLE
fix: suppress hydration warnings

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -21,8 +21,10 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
-      <body className={dmSans.className}>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body suppressHydrationWarning className={dmSans.variable}>
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
Added suppressHydrationWarning attribute to both html and body elements to prevent React hydration errors caused by browser extensions.