### PR TITLE
Remove network calls from middleware session handling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "embla-carousel-react": "^8.5.2",
         "framer-motion": "^12.4.10",
         "gsap": "^3.12.7",
-        "jose": "^6.0.11",
+        "jose": "^6.1.0",
         "lucide-react": "^0.479.0",
         "next": "^15.2.3",
         "postgres": "^3.4.5",
@@ -9624,9 +9624,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
-      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "embla-carousel-react": "^8.5.2",
     "framer-motion": "^12.4.10",
     "gsap": "^3.12.7",
-    "jose": "^6.0.11",
+    "jose": "^6.1.0",
     "lucide-react": "^0.479.0",
     "next": "^15.2.3",
     "postgres": "^3.4.5",
@@ -61,8 +61,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@types/bcryptjs": "^2.4.6",
     "@types/aos": "^3.0.7",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "22.13.10",
     "@types/react-dom": "^19.1.5",
     "autoprefixer": "^10.4.21",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,12 +2,6 @@ import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "../utils/supabase/middleware";
 
 export async function middleware(request: NextRequest) {
-  // Allows admin login page to bypass all auth checks
-  if (request.nextUrl.pathname === "/admin-login-portal") {
-    return NextResponse.next();
-  }
-
-  // For all other routes, run existing Supabase session logic
   return await updateSession(request);
 }
 


### PR DESCRIPTION
Refactor authentication and session management logic for Supabase in the middleware. Middleware now just checks for Authentication **NOT** Authorization as that requires network calls.

Pages/Layouts should be updated to check if a user is authorized. I will update this PR after we are done converting to server components and implement those checks.

* Refactored `updateSession` in `utils/supabase/middleware.ts` to validate JWTs using `jwtVerify` from `jose`, ensuring sessions cannot be forged by manipulating cookies. 
* `updateSession` falls back to `supabase.auth.getUser()` if JWT is invalid or expired.
* users are redirected to `/login` if accessing `/user` or `/admin` routes without authentication. 
* Removed admin role checks and cookie copying logic for redirects from `utils/supabase/middleware.ts`.
* Removed bypass logic for `/admin-login-portal` and all custom authentication checks from `src/middleware.ts`. 